### PR TITLE
Allow setting custom template

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Role Variables
 * `rsyslog_journald_size` --- `1G`
 * `rsyslog_config` --- list of dicts configuring syslog servers - see below for dictionary keywords, default `[]`
     * `type` --- syslog type - defaults to forward, default `omfwd`
+    * `template` --- sets a custom default template for this module, default depends on the module
     * `resume_retry_count` --- number of retries before loosing data, default `-1`
     * `queue_type` --- which kind of queue to use, default `LinkedList`
     * `queue_size` --- max size of the queue, default `10000`

--- a/templates/rsyslog-ver-8.conf.j2
+++ b/templates/rsyslog-ver-8.conf.j2
@@ -1,5 +1,8 @@
 {% for l in rsyslog_config %}
 *.* action(type="{{ l.type | default('omfwd') }}"
+{% if 'template' in l and l.template %}
+template="{{ l.template }}"
+{% endif %}
 queue.type="{{ l.queue_type | default('LinkedList') }}"
 action.resumeRetryCount="{{ l.resume_retry_count | default(-1)  }}"
 queue.size="{{ l.queue_size | default(10000) }}"


### PR DESCRIPTION
Hi!

I'd like to contribute feature.

`omfwd` supports customization of templates, this PR makes it possible to specify `template` parameter. Note: AFAICT not all modules support parameter, so it's only added when specified. Similarly default value depends on module. 

I confirm that my contributions will be compatible with the GPLv2.0 license guidelines.

* [x] I have read and accepted both license and code of conduct.
* [x] I have previously accepted and still accept both license and code of conduct.
